### PR TITLE
fix: `TableCalendar`のヘッダースタイルを更新し、ロケールを日本語に設定

### DIFF
--- a/lib/screens/introspection_list_screen.dart
+++ b/lib/screens/introspection_list_screen.dart
@@ -129,6 +129,11 @@ class IntrospectionListPage extends GetView<IntrospectionListScreenController> {
               onDaySelected: (selectedDay, focusedDay) {
                 controller.changeSelectedDate(selectedDay);
               },
+              headerStyle: const HeaderStyle(
+                formatButtonVisible: false,
+                titleCentered: true,
+              ),
+              locale: 'ja_JP'
             ),
           ),
           // Expandedを削除し、ListView.builderにshrinkWrapを適用


### PR DESCRIPTION
テーブルカレンダーも日本語対応
`2weeks`のボタン削除

<img src="https://github.com/user-attachments/assets/6d6932e6-193b-4d9d-8c30-afa96eaec744" width="300px" />