### PR TITLE
日記のリストをページネーションで読み込むように変更

### DIFF
--- a/lib/controller/introspection_list_screen_controller.dart
+++ b/lib/controller/introspection_list_screen_controller.dart
@@ -10,12 +10,21 @@ class IntrospectionListScreenController extends GetxController {
   final _notes = <IntrospectionNote>[].obs;
   final _filteredNotes = <IntrospectionNote>[].obs;
   final _isLoading = true.obs;
+  final _isMoreLoading = false.obs;
+  final _hasMore = true.obs;
   final _viewMode = ViewMode.list.obs;
   final _selectedDate = DateTime.now().obs;
   final Rx<IntrospectionNote?> _manipulatingNote = Rx<IntrospectionNote?>(null);
+
+  final ScrollController scrollController = ScrollController();
+  int _currentOffset = 0;
+  static const int _pageSize = 30;
+
   List<IntrospectionNote> get notes => _notes.toList();
   List<IntrospectionNote> get filteredNotes => _filteredNotes.toList();
   bool get isLoading => _isLoading.value;
+  bool get isMoreLoading => _isMoreLoading.value;
+  bool get hasMore => _hasMore.value;
   ViewMode get viewMode => _viewMode.value;
   IntrospectionNote? get manipulatingNote => _manipulatingNote.value;
   DateTime get selectedDate => _selectedDate.value;
@@ -23,20 +32,83 @@ class IntrospectionListScreenController extends GetxController {
   @override
   void onInit() {
     super.onInit();
+    scrollController.addListener(_scrollListener);
     readNotes();
+  }
+
+  @override
+  void onClose() {
+    scrollController.dispose();
+    super.onClose();
+  }
+
+  void _scrollListener() {
+    if (!scrollController.hasClients ||
+        _viewMode.value != ViewMode.list ||
+        _isLoading.value ||
+        _isMoreLoading.value ||
+        !_hasMore.value) {
+      return;
+    }
+
+    try {
+      if (scrollController.position.pixels >=
+          scrollController.position.maxScrollExtent - 200) {
+        loadMore();
+      }
+    } catch (e) {
+      // エラー無視
+    }
   }
 
   Future<void> readNotes() async {
     _isLoading.value = true;
+    _isMoreLoading.value = false;
+    _currentOffset = 0;
+    _hasMore.value = true;
     try {
-      final notes = await repository.fetchNotes();
-      _notes.clear();
-      _notes.addAll(notes);
+      final notes = await repository.fetchNotes(
+        limit: _pageSize,
+        offset: _currentOffset,
+      );
+      _notes.assignAll(notes);
+      _currentOffset += notes.length;
+      if (notes.length < _pageSize) {
+        _hasMore.value = false;
+      }
       filterNotesByDate(_selectedDate.value);
     } catch (e) {
       e.printError();
     } finally {
       _isLoading.value = false;
+      update();
+    }
+  }
+
+  Future<void> loadMore() async {
+    if (_isMoreLoading.value || !_hasMore.value) return;
+
+    _isMoreLoading.value = true;
+    update();
+    try {
+      final notes = await repository.fetchNotes(
+        limit: _pageSize,
+        offset: _currentOffset,
+      );
+      if (notes.isEmpty) {
+        _hasMore.value = false;
+      } else {
+        _notes.addAll(notes);
+        _currentOffset += notes.length;
+        if (notes.length < _pageSize) {
+          _hasMore.value = false;
+        }
+      }
+      filterNotesByDate(_selectedDate.value);
+    } catch (e) {
+      e.printError();
+    } finally {
+      _isMoreLoading.value = false;
       update();
     }
   }

--- a/lib/data/repositories/note_repository.dart
+++ b/lib/data/repositories/note_repository.dart
@@ -4,7 +4,7 @@ import 'package:introspection_note_mvp/data/models/introspection_note.dart';
 import 'package:sqflite/sqflite.dart';
 
 class NoteRepository {
-  Future<List<IntrospectionNote>> fetchNotes() async => [];
+  Future<List<IntrospectionNote>> fetchNotes({int? limit, int? offset}) async => [];
   Future<void> add(IntrospectionNote note) async {}
   Future<void> update(IntrospectionNote note) async {}
   Future<void> delete(IntrospectionNote note) async {}
@@ -17,11 +17,13 @@ class NoteRepositoryImpl extends NoteRepository {
   final DatabaseHelper dbHelper;
 
   @override
-  Future<List<IntrospectionNote>> fetchNotes() async {
+  Future<List<IntrospectionNote>> fetchNotes({int? limit, int? offset}) async {
     final db = await dbHelper.database;
     final maps = await db.query(
       DatabaseHelper.table,
       orderBy: '${DatabaseHelper.columnDate} DESC',
+      limit: limit,
+      offset: offset,
     );
 
     return List.generate(maps.length, (i) {
@@ -78,10 +80,18 @@ class NoteRepositoryImpl extends NoteRepository {
 
 class NoteRepositoryFakeImpl extends NoteRepository {
   @override
-  Future<List<IntrospectionNote>> fetchNotes() async {
+  Future<List<IntrospectionNote>> fetchNotes({int? limit, int? offset}) async {
     await Future.delayed(const Duration(seconds: 1));
     notes.sort((a, b) => b.date.compareTo(a.date));
-    return notes;
+    List<IntrospectionNote> result = notes;
+    if (offset != null) {
+      if (offset >= result.length) return [];
+      result = result.sublist(offset);
+    }
+    if (limit != null && result.length > limit) {
+      result = result.sublist(0, limit);
+    }
+    return result.toList();
   }
 
   @override

--- a/lib/screens/debug_screen.dart
+++ b/lib/screens/debug_screen.dart
@@ -1,0 +1,73 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:introspection_note_mvp/controller/introspection_list_screen_controller.dart';
+import 'package:introspection_note_mvp/data/models/introspection_note.dart';
+import 'package:introspection_note_mvp/data/repositories/note_repository.dart';
+import 'package:uuid/uuid.dart';
+
+class DebugScreen extends StatefulWidget {
+  const DebugScreen({super.key});
+
+  @override
+  State<DebugScreen> createState() => _DebugScreenState();
+}
+
+class _DebugScreenState extends State<DebugScreen> {
+  bool _isLoading = false;
+
+  Future<void> _addDummyData() async {
+    setState(() {
+      _isLoading = true;
+    });
+
+    final repository = Get.find<NoteRepository>();
+    final random = Random();
+    final now = DateTime.now();
+
+    for (int i = 0; i < 30; i++) {
+      final daysAgo = random.nextInt(60); // 過去60日間のランダムな日付
+      final noteDate = now.subtract(Duration(days: daysAgo));
+
+      final note = IntrospectionNote(
+        id: const Uuid().v4(),
+        date: noteDate,
+        positiveItems: ['ダミーの良いこと ${i + 1}-1', 'ダミーの良いこと ${i + 1}-2'],
+        improvementItems: ['ダミーの改善点 ${i + 1}-1', 'ダミーの改善点 ${i + 1}-2'],
+        dailyComment: 'これはダミーデータ${i + 1}です。ページネーションのテスト用に追加されました。',
+      );
+
+      await repository.add(note);
+    }
+
+    if (Get.isRegistered<IntrospectionListScreenController>()) {
+      Get.find<IntrospectionListScreenController>().readNotes();
+    }
+
+    setState(() {
+      _isLoading = false;
+    });
+
+    if (mounted) {
+      Get.snackbar('成功', '30件のダミーデータを追加しました。');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('デバッグ画面'),
+      ),
+      body: Center(
+        child: _isLoading
+            ? const CircularProgressIndicator()
+            : ElevatedButton(
+                onPressed: _addDummyData,
+                child: const Text('30件のダミーデータを追加する'),
+              ),
+      ),
+    );
+  }
+}

--- a/lib/screens/introspection_list_screen.dart
+++ b/lib/screens/introspection_list_screen.dart
@@ -1,8 +1,10 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:introspection_note_mvp/controller/introspection_list_screen_controller.dart';
 import 'package:introspection_note_mvp/data/models/introspection_note.dart';
 import 'package:introspection_note_mvp/data/models/modify_form_color_scheme.dart';
+import 'package:introspection_note_mvp/screens/debug_screen.dart';
 import 'package:introspection_note_mvp/util/util.dart';
 import 'package:introspection_note_mvp/widget/introspection_card.dart';
 import 'package:table_calendar/table_calendar.dart';
@@ -18,6 +20,11 @@ class IntrospectionListPage extends GetView<IntrospectionListScreenController> {
       appBar: AppBar(
         title: const Text('内省ノート'),
         actions: [
+          if (kDebugMode)
+            IconButton(
+              onPressed: () => Get.to(() => const DebugScreen()),
+              icon: const Icon(Icons.bug_report),
+            ),
           IconButton(
             onPressed: controller.navigateToSettingsScreen,
             icon: const Icon(Icons.settings),
@@ -93,8 +100,17 @@ class IntrospectionListPage extends GetView<IntrospectionListScreenController> {
       child:
           notes.isNotEmpty
               ? ListView.builder(
-                itemCount: notes.length,
+                controller: controller.scrollController,
+                itemCount: notes.length + (controller.isMoreLoading ? 1 : 0),
                 itemBuilder: (context, index) {
+                  if (index == notes.length) {
+                    return const Center(
+                      child: Padding(
+                        padding: EdgeInsets.symmetric(vertical: 16.0),
+                        child: CircularProgressIndicator(),
+                      ),
+                    );
+                  }
                   final note = notes[index];
                   return Padding(
                     padding: const EdgeInsets.only(bottom: 16.0),


### PR DESCRIPTION
現状の実装では日記のデータすべてを起動時に読み込んでいるのにアプリの利用期間が長くなるほど、UXが悪化していた。そのためデータを30件ずつページネーションして読み込むように変更を加えた